### PR TITLE
Ajout d’un fichier custom.css pour le thème de la BdV

### DIFF
--- a/theme/vagabonds/custom.css
+++ b/theme/vagabonds/custom.css
@@ -1,0 +1,3 @@
+ul.creditRate {
+  list-style: none;
+}


### PR DESCRIPTION
![bug](https://github.com/FondationSCP/fondationscp.github.io/assets/19653047/a10d7f6d-0cb2-4208-bd83-0995cda4095b)

Message originel en chan staff :

> On a un point qui apparaît sur la BdV à cause du caractère \<ul\> d’une balise du module de crédit (c.f l’image), il faudrait changer ce code
> ```css
> ul:not(.yui-nav) {
>     list-style: inside;
> 
>     #page-content & {
>         padding-left: 1em;
>     }
> }
> ```
> En rajoutant `.creditRate` dans le `not`, pour qu’une propriété CSS en-dessous qui fait `list-style: none;` ne soit pas surchargée

Correction en rajoutant une règle spécifique, dans un fichier séparé pour les modifications du thème de la BdV (le thème original étant directement puisé du wiki original) qui sera à ajouter sur le site.